### PR TITLE
Add the syslog facility instead of using the default (KERN)

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,4 +1,4 @@
-//Package gologging provides a logger implementation based on the github.com/op/go-logging pkg
+// Package gologging provides a logger implementation based on the github.com/op/go-logging pkg
 package gologging
 
 import (


### PR DESCRIPTION
Add a FormatterSelector for syslog with custom format. Default facility set to LOCAL3.

Adds a new configuration option "_syslog_facility_" which can be any of "local0" to "local7". If no valid value is provided the default facility will be used.